### PR TITLE
fix: correct method signature format in error messages

### DIFF
--- a/internal/patterns/callback_calls_deriver_or_ctx_derived.go
+++ b/internal/patterns/callback_calls_deriver_or_ctx_derived.go
@@ -201,7 +201,7 @@ func (p *CallbackCallsDeriverOrCtxDerived) findConstructorFromIdent(cctx *contex
 func (*CallbackCallsDeriverOrCtxDerived) Message(apiName string, _ string) string {
 	parts := splitAPIName(apiName)
 	if len(parts) == 3 {
-		return "(*" + parts[0] + "." + parts[1] + ")." + parts[2] + "() 1st argument should call goroutine deriver"
+		return parts[0] + ".(*" + parts[1] + ")." + parts[2] + "() 1st argument should call goroutine deriver"
 	}
 	return apiName + "() 1st argument should call goroutine deriver"
 }

--- a/testdata/src/gotask/basic.go
+++ b/testdata/src/gotask/basic.go
@@ -94,7 +94,7 @@ func badTaskDoAsyncNoDeriver(ctx context.Context) {
 	})
 	errChan := make(chan error)
 
-	task.DoAsync(ctx, errChan) // want `\(\*gotask\.Task\)\.DoAsync\(\) 1st argument should call goroutine deriver`
+	task.DoAsync(ctx, errChan) // want `gotask\.\(\*Task\)\.DoAsync\(\) 1st argument should call goroutine deriver`
 }
 
 // [BAD]: Task - with nil channel (ctx still needs deriver)
@@ -105,7 +105,7 @@ func badTaskDoAsyncNilChannel(ctx context.Context) {
 		return nil
 	})
 
-	task.DoAsync(ctx, nil) // want `\(\*gotask\.Task\)\.DoAsync\(\) 1st argument should call goroutine deriver`
+	task.DoAsync(ctx, nil) // want `gotask\.\(\*Task\)\.DoAsync\(\) 1st argument should call goroutine deriver`
 }
 
 // [BAD]: CancelableTask - with deriver
@@ -117,7 +117,7 @@ func badCancelableTaskDoAsyncNoDeriver(ctx context.Context) {
 	}).Cancelable()
 	errChan := make(chan error)
 
-	task.DoAsync(ctx, errChan) // want `\(\*gotask\.CancelableTask\)\.DoAsync\(\) 1st argument should call goroutine deriver`
+	task.DoAsync(ctx, errChan) // want `gotask\.\(\*CancelableTask\)\.DoAsync\(\) 1st argument should call goroutine deriver`
 }
 
 // ===== DoAllFnsSettled - SHOULD NOT REPORT =====

--- a/testdata/src/gotask/evil.go
+++ b/testdata/src/gotask/evil.go
@@ -86,7 +86,7 @@ func goodDerivedInIfBranch(ctx context.Context) {
 func badChainedTaskDoAsync(ctx context.Context) {
 	gotask.NewTask(func(ctx context.Context) error {
 		return nil
-	}).DoAsync(ctx, nil) // want `\(\*gotask\.Task\)\.DoAsync\(\) 1st argument should call goroutine deriver`
+	}).DoAsync(ctx, nil) // want `gotask\.\(\*Task\)\.DoAsync\(\) 1st argument should call goroutine deriver`
 }
 
 // [BAD]: Cancelable chain DoAsync without deriver
@@ -95,7 +95,7 @@ func badChainedTaskDoAsync(ctx context.Context) {
 func badCancelableChainDoAsync(ctx context.Context) {
 	gotask.NewTask(func(ctx context.Context) error {
 		return nil
-	}).Cancelable().DoAsync(ctx, nil) // want `\(\*gotask\.CancelableTask\)\.DoAsync\(\) 1st argument should call goroutine deriver`
+	}).Cancelable().DoAsync(ctx, nil) // want `gotask\.\(\*CancelableTask\)\.DoAsync\(\) 1st argument should call goroutine deriver`
 }
 
 // ===== METHOD CHAINING - SHOULD NOT REPORT =====
@@ -204,7 +204,7 @@ func badTaskPointerDoAsync(ctx context.Context) {
 		return nil
 	})
 	taskPtr := &task
-	taskPtr.DoAsync(ctx, nil) // want `\(\*gotask\.Task\)\.DoAsync\(\) 1st argument should call goroutine deriver`
+	taskPtr.DoAsync(ctx, nil) // want `gotask\.\(\*Task\)\.DoAsync\(\) 1st argument should call goroutine deriver`
 }
 
 // ===== DOASYNC ON POINTER - SHOULD NOT REPORT =====
@@ -284,9 +284,9 @@ func badMultipleDoAsync(ctx context.Context) {
 	task1 := gotask.NewTask(func(ctx context.Context) error { return nil })
 	task2 := gotask.NewTask(func(ctx context.Context) error { return nil })
 
-	task1.DoAsync(ctx, nil)                          // want `\(\*gotask\.Task\)\.DoAsync\(\) 1st argument should call goroutine deriver`
+	task1.DoAsync(ctx, nil)                          // want `gotask\.\(\*Task\)\.DoAsync\(\) 1st argument should call goroutine deriver`
 	task2.DoAsync(apm.NewGoroutineContext(ctx), nil) // OK - has deriver
-	task1.DoAsync(ctx, nil)                          // want `\(\*gotask\.Task\)\.DoAsync\(\) 1st argument should call goroutine deriver`
+	task1.DoAsync(ctx, nil)                          // want `gotask\.\(\*Task\)\.DoAsync\(\) 1st argument should call goroutine deriver`
 }
 
 // [BAD]: Edge case: Context with different param name
@@ -424,7 +424,7 @@ func badPointerDereferenceDoAsync(ctx context.Context) {
 		return nil
 	})
 	taskPtr := &task
-	(*taskPtr).DoAsync(ctx, nil) // want `\(\*gotask\.Task\)\.DoAsync\(\) 1st argument should call goroutine deriver`
+	(*taskPtr).DoAsync(ctx, nil) // want `gotask\.\(\*Task\)\.DoAsync\(\) 1st argument should call goroutine deriver`
 }
 
 // [GOOD]: Pointer dereference DoAsync without deriver


### PR DESCRIPTION
## Summary
- Fix method signature format in error messages from `(*pkg.Type).Method()` to `pkg.(*Type).Method()`
- This follows the standard Go method expression notation

## Changes
- `internal/patterns/callback_calls_deriver_or_ctx_derived.go`: Fix `Message()` function to generate correct format
- `testdata/src/gotask/basic.go`: Update expected error messages in test cases
- `testdata/src/gotask/evil.go`: Update expected error messages in test cases

## Test plan
- [x] Run `go test ./...` - all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)