### PR TITLE
refactor: use external tests and add t.Parallel()

### DIFF
--- a/internal/directive/carrier/carrier_test.go
+++ b/internal/directive/carrier/carrier_test.go
@@ -1,8 +1,14 @@
-package carrier
+package carrier_test
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/mpyw/goroutinectx/internal/directive/carrier"
+)
 
 func TestMatchPkg(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name      string
 		pkgPath   string
@@ -61,7 +67,9 @@ func TestMatchPkg(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := matchPkg(tt.pkgPath, tt.targetPkg); got != tt.want {
+			t.Parallel()
+
+			if got := carrier.MatchPkg(tt.pkgPath, tt.targetPkg); got != tt.want {
 				t.Errorf("matchPkg(%q, %q) = %v, want %v", tt.pkgPath, tt.targetPkg, got, tt.want)
 			}
 		})
@@ -69,10 +77,12 @@ func TestMatchPkg(t *testing.T) {
 }
 
 func TestParse(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name  string
 		input string
-		want  []Carrier
+		want  []carrier.Carrier
 	}{
 		{
 			name:  "empty string",
@@ -82,33 +92,35 @@ func TestParse(t *testing.T) {
 		{
 			name:  "single carrier",
 			input: "github.com/example/pkg.Type",
-			want:  []Carrier{{PkgPath: "github.com/example/pkg", TypeName: "Type"}},
+			want:  []carrier.Carrier{{PkgPath: "github.com/example/pkg", TypeName: "Type"}},
 		},
 		{
 			name:  "multiple carriers",
 			input: "pkg1.Type1,pkg2.Type2",
-			want:  []Carrier{{PkgPath: "pkg1", TypeName: "Type1"}, {PkgPath: "pkg2", TypeName: "Type2"}},
+			want:  []carrier.Carrier{{PkgPath: "pkg1", TypeName: "Type1"}, {PkgPath: "pkg2", TypeName: "Type2"}},
 		},
 		{
 			name:  "with spaces",
 			input: " pkg1.Type1 , pkg2.Type2 ",
-			want:  []Carrier{{PkgPath: "pkg1", TypeName: "Type1"}, {PkgPath: "pkg2", TypeName: "Type2"}},
+			want:  []carrier.Carrier{{PkgPath: "pkg1", TypeName: "Type1"}, {PkgPath: "pkg2", TypeName: "Type2"}},
 		},
 		{
 			name:  "invalid format - no dot",
 			input: "invalid",
-			want:  []Carrier{},
+			want:  []carrier.Carrier{},
 		},
 		{
 			name:  "empty parts are skipped",
 			input: "pkg.Type,,other.Type",
-			want:  []Carrier{{PkgPath: "pkg", TypeName: "Type"}, {PkgPath: "other", TypeName: "Type"}},
+			want:  []carrier.Carrier{{PkgPath: "pkg", TypeName: "Type"}, {PkgPath: "other", TypeName: "Type"}},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := Parse(tt.input)
+			t.Parallel()
+
+			got := carrier.Parse(tt.input)
 			if len(got) != len(tt.want) {
 				t.Errorf("Parse(%q) returned %d carriers, want %d", tt.input, len(got), len(tt.want))
 				return

--- a/internal/directive/carrier/export_test.go
+++ b/internal/directive/carrier/export_test.go
@@ -1,0 +1,3 @@
+package carrier
+
+var MatchPkg = matchPkg

--- a/internal/probe/composite_test.go
+++ b/internal/probe/composite_test.go
@@ -1,12 +1,16 @@
-package probe
+package probe_test
 
 import (
 	"go/ast"
 	"go/token"
 	"testing"
+
+	"github.com/mpyw/goroutinectx/internal/probe"
 )
 
 func TestFuncLitOfLiteralKey(t *testing.T) {
+	t.Parallel()
+
 	// Helper to create a FuncLit
 	makeFuncLit := func() *ast.FuncLit {
 		return &ast.FuncLit{
@@ -16,6 +20,8 @@ func TestFuncLitOfLiteralKey(t *testing.T) {
 	}
 
 	t.Run("INT index valid", func(t *testing.T) {
+		t.Parallel()
+
 		fl0 := makeFuncLit()
 		fl1 := makeFuncLit()
 		compLit := &ast.CompositeLit{
@@ -23,74 +29,86 @@ func TestFuncLitOfLiteralKey(t *testing.T) {
 		}
 		lit := &ast.BasicLit{Kind: token.INT, Value: "1"}
 
-		result := funcLitOfLiteralKey(compLit, lit)
+		result := probe.FuncLitOfLiteralKey(compLit, lit)
 		if result != fl1 {
 			t.Errorf("expected fl1, got %v", result)
 		}
 	})
 
 	t.Run("INT index zero", func(t *testing.T) {
+		t.Parallel()
+
 		fl0 := makeFuncLit()
 		compLit := &ast.CompositeLit{
 			Elts: []ast.Expr{fl0},
 		}
 		lit := &ast.BasicLit{Kind: token.INT, Value: "0"}
 
-		result := funcLitOfLiteralKey(compLit, lit)
+		result := probe.FuncLitOfLiteralKey(compLit, lit)
 		if result != fl0 {
 			t.Errorf("expected fl0, got %v", result)
 		}
 	})
 
 	t.Run("INT index out of range negative", func(t *testing.T) {
+		t.Parallel()
+
 		compLit := &ast.CompositeLit{
 			Elts: []ast.Expr{makeFuncLit()},
 		}
 		lit := &ast.BasicLit{Kind: token.INT, Value: "-1"}
 
-		result := funcLitOfLiteralKey(compLit, lit)
+		result := probe.FuncLitOfLiteralKey(compLit, lit)
 		if result != nil {
 			t.Errorf("expected nil for negative index, got %v", result)
 		}
 	})
 
 	t.Run("INT index out of range positive", func(t *testing.T) {
+		t.Parallel()
+
 		compLit := &ast.CompositeLit{
 			Elts: []ast.Expr{makeFuncLit()},
 		}
 		lit := &ast.BasicLit{Kind: token.INT, Value: "5"}
 
-		result := funcLitOfLiteralKey(compLit, lit)
+		result := probe.FuncLitOfLiteralKey(compLit, lit)
 		if result != nil {
 			t.Errorf("expected nil for out of range index, got %v", result)
 		}
 	})
 
 	t.Run("INT index invalid format", func(t *testing.T) {
+		t.Parallel()
+
 		compLit := &ast.CompositeLit{
 			Elts: []ast.Expr{makeFuncLit()},
 		}
 		lit := &ast.BasicLit{Kind: token.INT, Value: "abc"}
 
-		result := funcLitOfLiteralKey(compLit, lit)
+		result := probe.FuncLitOfLiteralKey(compLit, lit)
 		if result != nil {
 			t.Errorf("expected nil for invalid int format, got %v", result)
 		}
 	})
 
 	t.Run("INT index element not FuncLit", func(t *testing.T) {
+		t.Parallel()
+
 		compLit := &ast.CompositeLit{
 			Elts: []ast.Expr{&ast.Ident{Name: "notFuncLit"}},
 		}
 		lit := &ast.BasicLit{Kind: token.INT, Value: "0"}
 
-		result := funcLitOfLiteralKey(compLit, lit)
+		result := probe.FuncLitOfLiteralKey(compLit, lit)
 		if result != nil {
 			t.Errorf("expected nil when element is not FuncLit, got %v", result)
 		}
 	})
 
 	t.Run("STRING key valid", func(t *testing.T) {
+		t.Parallel()
+
 		fl := makeFuncLit()
 		compLit := &ast.CompositeLit{
 			Elts: []ast.Expr{
@@ -102,13 +120,15 @@ func TestFuncLitOfLiteralKey(t *testing.T) {
 		}
 		lit := &ast.BasicLit{Kind: token.STRING, Value: `"mykey"`}
 
-		result := funcLitOfLiteralKey(compLit, lit)
+		result := probe.FuncLitOfLiteralKey(compLit, lit)
 		if result != fl {
 			t.Errorf("expected fl, got %v", result)
 		}
 	})
 
 	t.Run("STRING key not found", func(t *testing.T) {
+		t.Parallel()
+
 		compLit := &ast.CompositeLit{
 			Elts: []ast.Expr{
 				&ast.KeyValueExpr{
@@ -119,13 +139,15 @@ func TestFuncLitOfLiteralKey(t *testing.T) {
 		}
 		lit := &ast.BasicLit{Kind: token.STRING, Value: `"mykey"`}
 
-		result := funcLitOfLiteralKey(compLit, lit)
+		result := probe.FuncLitOfLiteralKey(compLit, lit)
 		if result != nil {
 			t.Errorf("expected nil when key not found, got %v", result)
 		}
 	})
 
 	t.Run("STRING key value not FuncLit", func(t *testing.T) {
+		t.Parallel()
+
 		compLit := &ast.CompositeLit{
 			Elts: []ast.Expr{
 				&ast.KeyValueExpr{
@@ -136,25 +158,29 @@ func TestFuncLitOfLiteralKey(t *testing.T) {
 		}
 		lit := &ast.BasicLit{Kind: token.STRING, Value: `"mykey"`}
 
-		result := funcLitOfLiteralKey(compLit, lit)
+		result := probe.FuncLitOfLiteralKey(compLit, lit)
 		if result != nil {
 			t.Errorf("expected nil when value is not FuncLit, got %v", result)
 		}
 	})
 
 	t.Run("STRING key element not KeyValueExpr", func(t *testing.T) {
+		t.Parallel()
+
 		compLit := &ast.CompositeLit{
 			Elts: []ast.Expr{makeFuncLit()}, // Not KeyValueExpr
 		}
 		lit := &ast.BasicLit{Kind: token.STRING, Value: `"mykey"`}
 
-		result := funcLitOfLiteralKey(compLit, lit)
+		result := probe.FuncLitOfLiteralKey(compLit, lit)
 		if result != nil {
 			t.Errorf("expected nil when element is not KeyValueExpr, got %v", result)
 		}
 	})
 
 	t.Run("STRING key key not BasicLit", func(t *testing.T) {
+		t.Parallel()
+
 		compLit := &ast.CompositeLit{
 			Elts: []ast.Expr{
 				&ast.KeyValueExpr{
@@ -165,19 +191,21 @@ func TestFuncLitOfLiteralKey(t *testing.T) {
 		}
 		lit := &ast.BasicLit{Kind: token.STRING, Value: `"mykey"`}
 
-		result := funcLitOfLiteralKey(compLit, lit)
+		result := probe.FuncLitOfLiteralKey(compLit, lit)
 		if result != nil {
 			t.Errorf("expected nil when key is not BasicLit, got %v", result)
 		}
 	})
 
 	t.Run("unsupported token kind", func(t *testing.T) {
+		t.Parallel()
+
 		compLit := &ast.CompositeLit{
 			Elts: []ast.Expr{makeFuncLit()},
 		}
 		lit := &ast.BasicLit{Kind: token.FLOAT, Value: "1.5"}
 
-		result := funcLitOfLiteralKey(compLit, lit)
+		result := probe.FuncLitOfLiteralKey(compLit, lit)
 		if result != nil {
 			t.Errorf("expected nil for unsupported token kind, got %v", result)
 		}

--- a/internal/probe/export_test.go
+++ b/internal/probe/export_test.go
@@ -1,0 +1,3 @@
+package probe
+
+var FuncLitOfLiteralKey = funcLitOfLiteralKey


### PR DESCRIPTION
## Summary
- Convert internal tests to external test packages (`foo_test` format)
- Add `t.Parallel()` to enable parallel test execution
- Create `export_test.go` files to expose unexported functions for testing

## Files Changed
- `internal/probe/composite_test.go`
- `internal/directive/carrier/carrier_test.go`

## Test plan
- [x] `go test ./...` passes locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)