### PR TITLE
fix: revert internal tests to internal package

### DIFF
--- a/internal/directive/carrier/carrier_test.go
+++ b/internal/directive/carrier/carrier_test.go
@@ -1,9 +1,7 @@
-package carrier_test
+package carrier
 
 import (
 	"testing"
-
-	"github.com/mpyw/goroutinectx/internal/directive/carrier"
 )
 
 func TestMatchPkg(t *testing.T) {
@@ -69,7 +67,7 @@ func TestMatchPkg(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			if got := carrier.MatchPkg(tt.pkgPath, tt.targetPkg); got != tt.want {
+			if got := matchPkg(tt.pkgPath, tt.targetPkg); got != tt.want {
 				t.Errorf("matchPkg(%q, %q) = %v, want %v", tt.pkgPath, tt.targetPkg, got, tt.want)
 			}
 		})
@@ -82,7 +80,7 @@ func TestParse(t *testing.T) {
 	tests := []struct {
 		name  string
 		input string
-		want  []carrier.Carrier
+		want  []Carrier
 	}{
 		{
 			name:  "empty string",
@@ -92,27 +90,27 @@ func TestParse(t *testing.T) {
 		{
 			name:  "single carrier",
 			input: "github.com/example/pkg.Type",
-			want:  []carrier.Carrier{{PkgPath: "github.com/example/pkg", TypeName: "Type"}},
+			want:  []Carrier{{PkgPath: "github.com/example/pkg", TypeName: "Type"}},
 		},
 		{
 			name:  "multiple carriers",
 			input: "pkg1.Type1,pkg2.Type2",
-			want:  []carrier.Carrier{{PkgPath: "pkg1", TypeName: "Type1"}, {PkgPath: "pkg2", TypeName: "Type2"}},
+			want:  []Carrier{{PkgPath: "pkg1", TypeName: "Type1"}, {PkgPath: "pkg2", TypeName: "Type2"}},
 		},
 		{
 			name:  "with spaces",
 			input: " pkg1.Type1 , pkg2.Type2 ",
-			want:  []carrier.Carrier{{PkgPath: "pkg1", TypeName: "Type1"}, {PkgPath: "pkg2", TypeName: "Type2"}},
+			want:  []Carrier{{PkgPath: "pkg1", TypeName: "Type1"}, {PkgPath: "pkg2", TypeName: "Type2"}},
 		},
 		{
 			name:  "invalid format - no dot",
 			input: "invalid",
-			want:  []carrier.Carrier{},
+			want:  []Carrier{},
 		},
 		{
 			name:  "empty parts are skipped",
 			input: "pkg.Type,,other.Type",
-			want:  []carrier.Carrier{{PkgPath: "pkg", TypeName: "Type"}, {PkgPath: "other", TypeName: "Type"}},
+			want:  []Carrier{{PkgPath: "pkg", TypeName: "Type"}, {PkgPath: "other", TypeName: "Type"}},
 		},
 	}
 
@@ -120,7 +118,7 @@ func TestParse(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := carrier.Parse(tt.input)
+			got := Parse(tt.input)
 			if len(got) != len(tt.want) {
 				t.Errorf("Parse(%q) returned %d carriers, want %d", tt.input, len(got), len(tt.want))
 				return

--- a/internal/directive/carrier/export_test.go
+++ b/internal/directive/carrier/export_test.go
@@ -1,3 +1,0 @@
-package carrier
-
-var MatchPkg = matchPkg

--- a/internal/probe/composite_test.go
+++ b/internal/probe/composite_test.go
@@ -1,11 +1,9 @@
-package probe_test
+package probe
 
 import (
 	"go/ast"
 	"go/token"
 	"testing"
-
-	"github.com/mpyw/goroutinectx/internal/probe"
 )
 
 func TestFuncLitOfLiteralKey(t *testing.T) {
@@ -29,7 +27,7 @@ func TestFuncLitOfLiteralKey(t *testing.T) {
 		}
 		lit := &ast.BasicLit{Kind: token.INT, Value: "1"}
 
-		result := probe.FuncLitOfLiteralKey(compLit, lit)
+		result := funcLitOfLiteralKey(compLit, lit)
 		if result != fl1 {
 			t.Errorf("expected fl1, got %v", result)
 		}
@@ -44,7 +42,7 @@ func TestFuncLitOfLiteralKey(t *testing.T) {
 		}
 		lit := &ast.BasicLit{Kind: token.INT, Value: "0"}
 
-		result := probe.FuncLitOfLiteralKey(compLit, lit)
+		result := funcLitOfLiteralKey(compLit, lit)
 		if result != fl0 {
 			t.Errorf("expected fl0, got %v", result)
 		}
@@ -58,7 +56,7 @@ func TestFuncLitOfLiteralKey(t *testing.T) {
 		}
 		lit := &ast.BasicLit{Kind: token.INT, Value: "-1"}
 
-		result := probe.FuncLitOfLiteralKey(compLit, lit)
+		result := funcLitOfLiteralKey(compLit, lit)
 		if result != nil {
 			t.Errorf("expected nil for negative index, got %v", result)
 		}
@@ -72,7 +70,7 @@ func TestFuncLitOfLiteralKey(t *testing.T) {
 		}
 		lit := &ast.BasicLit{Kind: token.INT, Value: "5"}
 
-		result := probe.FuncLitOfLiteralKey(compLit, lit)
+		result := funcLitOfLiteralKey(compLit, lit)
 		if result != nil {
 			t.Errorf("expected nil for out of range index, got %v", result)
 		}
@@ -86,7 +84,7 @@ func TestFuncLitOfLiteralKey(t *testing.T) {
 		}
 		lit := &ast.BasicLit{Kind: token.INT, Value: "abc"}
 
-		result := probe.FuncLitOfLiteralKey(compLit, lit)
+		result := funcLitOfLiteralKey(compLit, lit)
 		if result != nil {
 			t.Errorf("expected nil for invalid int format, got %v", result)
 		}
@@ -100,7 +98,7 @@ func TestFuncLitOfLiteralKey(t *testing.T) {
 		}
 		lit := &ast.BasicLit{Kind: token.INT, Value: "0"}
 
-		result := probe.FuncLitOfLiteralKey(compLit, lit)
+		result := funcLitOfLiteralKey(compLit, lit)
 		if result != nil {
 			t.Errorf("expected nil when element is not FuncLit, got %v", result)
 		}
@@ -120,7 +118,7 @@ func TestFuncLitOfLiteralKey(t *testing.T) {
 		}
 		lit := &ast.BasicLit{Kind: token.STRING, Value: `"mykey"`}
 
-		result := probe.FuncLitOfLiteralKey(compLit, lit)
+		result := funcLitOfLiteralKey(compLit, lit)
 		if result != fl {
 			t.Errorf("expected fl, got %v", result)
 		}
@@ -139,7 +137,7 @@ func TestFuncLitOfLiteralKey(t *testing.T) {
 		}
 		lit := &ast.BasicLit{Kind: token.STRING, Value: `"mykey"`}
 
-		result := probe.FuncLitOfLiteralKey(compLit, lit)
+		result := funcLitOfLiteralKey(compLit, lit)
 		if result != nil {
 			t.Errorf("expected nil when key not found, got %v", result)
 		}
@@ -158,7 +156,7 @@ func TestFuncLitOfLiteralKey(t *testing.T) {
 		}
 		lit := &ast.BasicLit{Kind: token.STRING, Value: `"mykey"`}
 
-		result := probe.FuncLitOfLiteralKey(compLit, lit)
+		result := funcLitOfLiteralKey(compLit, lit)
 		if result != nil {
 			t.Errorf("expected nil when value is not FuncLit, got %v", result)
 		}
@@ -172,7 +170,7 @@ func TestFuncLitOfLiteralKey(t *testing.T) {
 		}
 		lit := &ast.BasicLit{Kind: token.STRING, Value: `"mykey"`}
 
-		result := probe.FuncLitOfLiteralKey(compLit, lit)
+		result := funcLitOfLiteralKey(compLit, lit)
 		if result != nil {
 			t.Errorf("expected nil when element is not KeyValueExpr, got %v", result)
 		}
@@ -191,7 +189,7 @@ func TestFuncLitOfLiteralKey(t *testing.T) {
 		}
 		lit := &ast.BasicLit{Kind: token.STRING, Value: `"mykey"`}
 
-		result := probe.FuncLitOfLiteralKey(compLit, lit)
+		result := funcLitOfLiteralKey(compLit, lit)
 		if result != nil {
 			t.Errorf("expected nil when key is not BasicLit, got %v", result)
 		}
@@ -205,7 +203,7 @@ func TestFuncLitOfLiteralKey(t *testing.T) {
 		}
 		lit := &ast.BasicLit{Kind: token.FLOAT, Value: "1.5"}
 
-		result := probe.FuncLitOfLiteralKey(compLit, lit)
+		result := funcLitOfLiteralKey(compLit, lit)
 		if result != nil {
 			t.Errorf("expected nil for unsupported token kind, got %v", result)
 		}

--- a/internal/probe/export_test.go
+++ b/internal/probe/export_test.go
@@ -1,3 +1,0 @@
-package probe
-
-var FuncLitOfLiteralKey = funcLitOfLiteralKey


### PR DESCRIPTION
## Summary
- Revert internal tests from external (`foo_test`) back to internal (`foo`) package
- Delete `export_test.go` files that were exporting unexported functions
- Keep `t.Parallel()` calls that were added

Testing unexported functions should use internal tests, not external tests with export hacks.

## Test plan
- [x] `go test ./...` passes locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)